### PR TITLE
Add page number validation

### DIFF
--- a/src/routes/hianime.ts
+++ b/src/routes/hianime.ts
@@ -29,8 +29,10 @@ hianimeRouter.get("/azlist/:sortOption", async (c) => {
     const sortOption = decodeURIComponent(
         c.req.param("sortOption").trim().toLowerCase()
     ) as HiAnime.AZListSortOptions;
-    const page: number =
+    let page: number =
         Number(decodeURIComponent(c.req.query("page") || "")) || 1;
+    // Ensure page is at least 1
+    page = Math.max(1, page);
 
     const data = await cache.getOrSet<HiAnime.ScrapedAnimeAZList>(
         async () => hianime.getAZList(sortOption, page),
@@ -61,8 +63,10 @@ hianimeRouter.get("/category/:name", async (c) => {
     const categoryName = decodeURIComponent(
         c.req.param("name").trim()
     ) as HiAnime.AnimeCategories;
-    const page: number =
+    let page: number =
         Number(decodeURIComponent(c.req.query("page") || "")) || 1;
+    // Ensure page is at least 1
+    page = Math.max(1, page);
 
     const data = await cache.getOrSet<HiAnime.ScrapedAnimeCategory>(
         async () => hianime.getCategoryAnime(categoryName, page),
@@ -77,8 +81,10 @@ hianimeRouter.get("/category/:name", async (c) => {
 hianimeRouter.get("/genre/:name", async (c) => {
     const cacheConfig = c.get("CACHE_CONFIG");
     const genreName = decodeURIComponent(c.req.param("name").trim());
-    const page: number =
+    let page: number =
         Number(decodeURIComponent(c.req.query("page") || "")) || 1;
+    // Ensure page is at least 1
+    page = Math.max(1, page);
 
     const data = await cache.getOrSet<HiAnime.ScrapedGenreAnime>(
         async () => hianime.getGenreAnime(genreName, page),


### PR DESCRIPTION
This pull request includes changes to ensure that the `page` parameter in several route handlers is always at least 1, improving input validation and preventing potential issues with invalid page numbers.

### Input Validation Improvements:
* In the `hianimeRouter.get("/azlist/:sortOption")` route, changed the `page` variable from `const` to `let` and added logic to ensure the `page` value is at least 1 using `Math.max(1, page)`. (`src/routes/hianime.ts`, [src/routes/hianime.tsL32-R35](diffhunk://#diff-b30f94a102276994cea8a5ab7bdab3a00de61e5a2c7945b81c9a7fbfda47c414L32-R35))
* In the `hianimeRouter.get("/category/:name")` route, updated the `page` variable similarly to ensure it is at least 1. (`src/routes/hianime.ts`, [src/routes/hianime.tsL64-R69](diffhunk://#diff-b30f94a102276994cea8a5ab7bdab3a00de61e5a2c7945b81c9a7fbfda47c414L64-R69))
* In the `hianimeRouter.get("/genre/:name")` route, applied the same `page` validation logic to guarantee a minimum value of 1. (`src/routes/hianime.ts`, [src/routes/hianime.tsL80-R87](diffhunk://#diff-b30f94a102276994cea8a5ab7bdab3a00de61e5a2c7945b81c9a7fbfda47c414L80-R87))